### PR TITLE
Update bring.ts fixing typos

### DIFF
--- a/src/bring.ts
+++ b/src/bring.ts
@@ -18,7 +18,7 @@ interface GetItemsResponse {
     uuid: string;
     status: string;
     purchase: GetItemsResponseEntry[];
-    rececently: GetItemsResponseEntry[];
+    recently: GetItemsResponseEntry[];
 }
 
 interface GetAllUsersFromListEntry {
@@ -41,7 +41,7 @@ interface LoadListsEntry {
     theme: string;
 }
 
-interface LoadListsFresponse {
+interface LoadListsResponse {
     lists: LoadListsEntry[];
 }
 


### PR DESCRIPTION
the typo that affects the "recently" property results in not being able to access the property in the response, but always returning an undefined object. the typo affecting the "LoadListsResponse" is only cosmetic in nature.